### PR TITLE
Render fix for JC2MP 0.2

### DIFF
--- a/client/quicktp.lua
+++ b/client/quicktp.lua
@@ -125,7 +125,7 @@ RenderMenu = function(args)
 
 	for i=2, #menu, 1 do
 		local t = menu[i]
-		if type(t) == "table" then t = t[1] .. (showGroupCount and " [" .. tostring(#t - 1) .. "]" or "") end
+		if type(t) == "table" then t = t[1]:trim() .. (showGroupCount and " [" .. tostring(#t - 1) .. "]" or "") end
 		if fontUpper then t = string.upper(t) end
 
 		textSize = Render:GetTextSize(t, size) 


### PR DESCRIPTION
Added a trim() method to fix a rendering issue. Seems to be unique to JC2MP 0.2 when the data is loaded from a Linux server.
